### PR TITLE
Update route regex for dash in container id

### DIFF
--- a/config/routes/container.yaml
+++ b/config/routes/container.yaml
@@ -8,7 +8,7 @@ container_form_show:
     methods: [GET]
     controller: App\Controller\Container\Form\Show::handle
     requirements:
-        id: '^[a-zA-Z]+$'
+        id: '^[a-zA-Z]+(-)?[a-zA-Z]+$'
 
 container_build:
     path: /build


### PR DESCRIPTION
Allow containers to have dash in their id (ex : php-fpm instead of phpfpm) 